### PR TITLE
Patch to extract tu's note when there's one

### DIFF
--- a/tmx2dataframe/tmx2dataframe.py
+++ b/tmx2dataframe/tmx2dataframe.py
@@ -10,6 +10,15 @@ def process_tuv(tuv):
     txt = seg.childNodes[0].data
     return lang, txt
 
+
+def extract_note(tu):
+    notes = tu.getElementsByTagName('note')
+    if len(notes) >= 1:
+        # if there's more than one note, only the first one will be extracted
+        # if all notes are to be extracted, they could be concatenated in the same value
+        return notes[0].childNodes[0].data
+
+
 def read(path):
 
     """Read function takes in a path to TMX translation file and outputs the metadata and a pandas dataframe.
@@ -51,6 +60,11 @@ def read(path):
                 'target_language': targetlang,
                 'target_sentence': targetsentence
             }
+
+            note = extract_note(tu)
+            if note:
+                item['note'] = note
+
             items.append(item)
 
     df = pd.DataFrame(items)


### PR DESCRIPTION
Dear @jaderabbit 

I found your module useful, but it didn't fulfil all my needs, as I also needed the tu/note extracted, if there's one. 

Hence I have patched your module to extract the tu's note when there's one. Only the first one is extracted if there's more than one. I only need the first one but if all notes were to be extracted, they could be concatenated in the same value (to be added to the note field in the dataframe). 

If you find my patch useful, you may want to accept my PR.
In any case, thanks a lot for your module, good work! 

Cheers, Manuel